### PR TITLE
mehtod-invocation: add error handling handler (GS-11691)

### DIFF
--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -4,7 +4,7 @@
   "description": "Interfaces to be used by Genestack system APIs",
   "main": "dist",
   "scripts": {
-    "build": "rm -r dist && tsc --declaration"
+    "build": "rm -rf dist && tsc --declaration"
   },
   "repository": {
     "type": "git",

--- a/packages/interfaces/src/handle-error-message.ts
+++ b/packages/interfaces/src/handle-error-message.ts
@@ -19,7 +19,7 @@ interface GenestackServerError {
     calledApplicationId: string;
     method: string;
     parameters: Array<any>;
-    notificationError: string;
+    notificationError: boolean;
     supportEmail: string;
 }
 

--- a/packages/interfaces/src/handle-error-message.ts
+++ b/packages/interfaces/src/handle-error-message.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2011-2018 Genestack Limited
+ * All Rights Reserved
+ * This source code is distributed under the MIT license:
+ * https://github.com/genestack/JS-SDK/tree/master/LICENSE
+ */
+
+import SystemMessage from './system-message';
+
+type HandleErrorMessageType = 'G$:handle-error';
+export const HANDLE_ERROR_MESSAGE_TYPE: HandleErrorMessageType = 'G$:handle-error';
+
+interface GenestackServerError {
+    name: string;
+    message: string;
+    stack: string;
+    serverStackTrace: string;
+    responseText: string;
+    calledApplicationId: string;
+    method: string;
+    parameters: Array<any>;
+    notificationError: string;
+    supportEmail: string;
+}
+
+export interface HandleErrorMessage extends SystemMessage {
+    type: HandleErrorMessageType;
+    payload: Error | GenestackServerError
+}

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -7,3 +7,4 @@
 
 export * from './entry-point';
 export * from './method-invocation-message'
+export * from './handle-error-message'

--- a/packages/interfaces/tsconfig.json
+++ b/packages/interfaces/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "CommonJS",
     "target": "ES5",
     "moduleResolution": "node",
+    "strict": true,
     "lib": [
       "dom",
       "es2015"

--- a/packages/system-api/package-lock.json
+++ b/packages/system-api/package-lock.json
@@ -5,9 +5,15 @@
   "requires": true,
   "dependencies": {
     "@genestack/interfaces": {
-      "version": "1.0.0-aplha.0",
-      "resolved": "https://npm.genestack.com/@genestack%2finterfaces/-/interfaces-1.0.0-aplha.0.tgz",
-      "integrity": "sha512-/PsgkkgKzPbas9EqDAAqfXyC2VwcI1vYUXQZ1fTSXT2E4K9nlvE3dI1gkx87eQW/5Y+M1cwj3UuAvpdph0/+5w=="
+      "version": "1.0.0-alpha.0",
+      "resolved": "https://npm.genestack.com/@genestack%2finterfaces/-/interfaces-1.0.0-alpha.0.tgz",
+      "integrity": "sha512-M8kEEp4YbVnPYyRbg9u0OTxcfED8qzzFmw9WyV9qvNvbhX3b/BPZkLTHNazDc7VuczzRX1KtHD5reQICp+ZahA=="
+    },
+    "typescript": {
+      "version": "2.9.2",
+      "resolved": "https://npm.genestack.com/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true
     }
   }
 }

--- a/packages/system-api/package.json
+++ b/packages/system-api/package.json
@@ -4,7 +4,7 @@
   "description": "Genestack system APIs to use in browser",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rm -r dist && tsc --declaration"
+    "build": "rm -rf dist && tsc --declaration"
   },
   "repository": {
     "type": "git",

--- a/packages/system-api/src/system-calls.ts
+++ b/packages/system-api/src/system-calls.ts
@@ -7,4 +7,4 @@
 
 import {systemCallSymbol, SystemCall} from '@genestack/interfaces';
 
-export const systemCall: SystemCall = window[systemCallSymbol];
+export const systemCall: SystemCall = (window as any)[systemCallSymbol];

--- a/packages/system-api/tsconfig.json
+++ b/packages/system-api/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "CommonJS",
     "target": "ES5",
     "moduleResolution": "node",
+    "strict": true,
     "lib": [
       "dom",
       "es2015"


### PR DESCRIPTION
Original defect: https://genestack.atlassian.net/browse/GS-11691

First of all, I just forgot about error handling, and the second – strict checks in TS are disabled by default (as it turned out).