### PR TITLE
api & interfaces: right package-locks.json files

### DIFF
--- a/packages/interfaces/package-lock.json
+++ b/packages/interfaces/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "@genestack/interfaces",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true
+    }
+  }
+}

--- a/packages/system-api/package-lock.json
+++ b/packages/system-api/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "@genestack/system-api",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@genestack/interfaces": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@genestack/interfaces/-/interfaces-1.0.0.tgz",
+      "integrity": "sha512-fncvP+ZBchaR2XO4O2ULdPVAyBiND4pDmXjeJbwN49Qrjd67rwOEoWyLlyHgZ4ML0sJ99uf9ii/3kTmlCuFjAw=="
+    },
+    "typescript": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true
+    }
+  }
+}


### PR DESCRIPTION
Just added right `package-lock.json` files. Had to do it from home, because _for some reasons_ npm's cache on my work machine cannot be cleared.