### PR TITLE
mehtod-invocation: error handilng promise

### DIFF
--- a/packages/system-api/src/invoke-method.ts
+++ b/packages/system-api/src/invoke-method.ts
@@ -53,7 +53,7 @@ export function invokeMethod(options: MethodInvocationOptions): Promise<any> {
                     };
                     systemCall(handleErrorMessage);
                 }
-                return error;
+                return Promise.reject(error);
             }
         );
 }


### PR DESCRIPTION
Catch handler will not be called if from rejection handler was returned not a rejected promise. 