### PR TITLE
EDM-459 add application URL to the ApplicationProperties interface

### DIFF
--- a/packages/interfaces/src/application-properties-message.ts
+++ b/packages/interfaces/src/application-properties-message.ts
@@ -26,7 +26,7 @@ export interface ApplicationProperties {
     parameters: Array<any>;
     action: string;
     isApplicationHome: boolean;
-    url: string;
+    pathname: string;
 }
 
 export interface ApplicationPropertiesMessage extends SystemMessage {

--- a/packages/interfaces/src/application-properties-message.ts
+++ b/packages/interfaces/src/application-properties-message.ts
@@ -26,6 +26,7 @@ export interface ApplicationProperties {
     parameters: Array<any>;
     action: string;
     isApplicationHome: boolean;
+    url: string;
 }
 
 export interface ApplicationPropertiesMessage extends SystemMessage {

--- a/packages/system-api/src/application.ts
+++ b/packages/system-api/src/application.ts
@@ -42,6 +42,9 @@ export function loadApplication() {
                 },
                 get applicationName() {
                     return appProperties.applicationName;
+                },
+                get url() {
+                    return appProperties.url;
                 }
             };
         });

--- a/packages/system-api/src/application.ts
+++ b/packages/system-api/src/application.ts
@@ -43,8 +43,8 @@ export function loadApplication() {
                 get applicationName() {
                     return appProperties.applicationName;
                 },
-                get url() {
-                    return appProperties.url;
+                get pathname() {
+                    return appProperties.pathname;
                 }
             };
         });


### PR DESCRIPTION
This PR resolves [that](https://genestack.atlassian.net/browse/EDM-459) Jira issue.
The `url` getter is required when the developer needs to know the Application URL endpoint.
This PR adds this to the interface and makes a new getter named `url`.