### PR TITLE
Revert "release/system-api@1.1.0"

### DIFF
--- a/packages/system-api/changelog.md
+++ b/packages/system-api/changelog.md
@@ -1,11 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.1.0] – 2018-11-22
-### Added
-- `showNotification()` method
-- `app.pathname` property in application object returned from `loadApplication()` method  
-
-## [1.0.2] – 2018-11-16
+## [1.0.2] - 2017-06-20
 ### Changed
 - fixed TypeScript typings path

--- a/packages/system-api/package-lock.json
+++ b/packages/system-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@genestack/system-api",
-  "version": "1.1.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/system-api/package.json
+++ b/packages/system-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genestack/system-api",
-  "version": "1.1.0",
+  "version": "1.0.2",
   "description": "Genestack system APIs to use in browser",
   "main": "dist",
   "typings": "dist",


### PR DESCRIPTION
It should rely on `@genestack/interfaces@1.1.0` but it is not released yet