### PR TITLE
ui-proxy: fix npm repo addres, vulnrability & readme (JBKB-23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 This mono-repository contains components of Genestack JavaScript 
 software development kit
 
-* [`@genestack/system-api` To use in browser](./packages/system-api/README.md) 
+* [`@genestack/system-api` To use in browser](./packages/system-api/README.md)
+* [`@genestack/ui-proxy` to see changes in your UI on top of Genestack application without
+  redeploy](./packages/ui-proxy/README.md)

--- a/packages/ui-proxy/package-lock.json
+++ b/packages/ui-proxy/package-lock.json
@@ -6,17 +6,17 @@
   "dependencies": {
     "ansi-regex": {
       "version": "0.2.1",
-      "resolved": "https://npm.genestack.com/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
       "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
     },
     "ansi-styles": {
       "version": "1.1.0",
-      "resolved": "https://npm.genestack.com/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
       "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
     },
     "anymatch": {
       "version": "2.0.0",
-      "resolved": "https://npm.genestack.com/anymatch/-/anymatch-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "requires": {
         "micromatch": "^3.1.4",
@@ -25,52 +25,52 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "https://npm.genestack.com/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://npm.genestack.com/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://npm.genestack.com/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "https://npm.genestack.com/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://npm.genestack.com/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://npm.genestack.com/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
       "version": "1.0.1",
-      "resolved": "https://npm.genestack.com/async-each/-/async-each-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
     },
-    "atob": {
-      "version": "2.1.1",
-      "resolved": "https://npm.genestack.com/atob/-/atob-2.1.1.tgz",
-      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
-    },
-    "balanced-match": {
+    "async-limiter": {
       "version": "1.0.0",
-      "resolved": "https://npm.genestack.com/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "https://npm.genestack.com/base/-/base-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
         "cache-base": "^1.0.1",
@@ -84,7 +84,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -92,7 +92,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -100,7 +100,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -108,7 +108,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://npm.genestack.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -119,22 +119,13 @@
       }
     },
     "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://npm.genestack.com/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://npm.genestack.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "https://npm.genestack.com/braces/-/braces-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
         "arr-flatten": "^1.1.0",
@@ -151,7 +142,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.genestack.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -161,7 +152,7 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "https://npm.genestack.com/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
         "collection-visit": "^1.0.0",
@@ -177,7 +168,7 @@
     },
     "chalk": {
       "version": "0.5.1",
-      "resolved": "https://npm.genestack.com/chalk/-/chalk-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
       "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
       "requires": {
         "ansi-styles": "^1.1.0",
@@ -189,7 +180,7 @@
     },
     "chokidar": {
       "version": "2.0.4",
-      "resolved": "https://npm.genestack.com/chokidar/-/chokidar-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "requires": {
         "anymatch": "^2.0.0",
@@ -209,7 +200,7 @@
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "https://npm.genestack.com/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
         "arr-union": "^3.1.0",
@@ -220,7 +211,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.genestack.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -230,7 +221,7 @@
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://npm.genestack.com/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
         "map-visit": "^1.0.0",
@@ -238,33 +229,28 @@
       }
     },
     "commander": {
-      "version": "2.16.0",
-      "resolved": "https://npm.genestack.com/commander/-/commander-2.16.0.tgz",
-      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "https://npm.genestack.com/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://npm.genestack.com/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://npm.genestack.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://npm.genestack.com/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "https://npm.genestack.com/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
@@ -272,12 +258,12 @@
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://npm.genestack.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "https://npm.genestack.com/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
         "is-descriptor": "^1.0.2",
@@ -286,7 +272,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -294,7 +280,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -302,7 +288,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://npm.genestack.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -314,12 +300,12 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://npm.genestack.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "https://npm.genestack.com/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
         "debug": "^2.3.3",
@@ -333,7 +319,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.genestack.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -341,7 +327,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.genestack.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -351,7 +337,7 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "https://npm.genestack.com/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -360,7 +346,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://npm.genestack.com/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -370,7 +356,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "https://npm.genestack.com/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
         "array-unique": "^0.3.2",
@@ -385,7 +371,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -393,7 +379,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.genestack.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -401,7 +387,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -409,7 +395,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -417,7 +403,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://npm.genestack.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -429,12 +415,12 @@
     },
     "file-size": {
       "version": "0.0.5",
-      "resolved": "https://npm.genestack.com/file-size/-/file-size-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/file-size/-/file-size-0.0.5.tgz",
       "integrity": "sha1-BX1Dw6Ptc12j+Q1gUqs4Dx5tXjs="
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "https://npm.genestack.com/fill-range/-/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -445,7 +431,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.genestack.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -455,12 +441,12 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://npm.genestack.com/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://npm.genestack.com/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
         "map-cache": "^0.2.2"
@@ -468,7 +454,7 @@
     },
     "fsevents": {
       "version": "1.2.4",
-      "resolved": "https://npm.genestack.com/fsevents/-/fsevents-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
@@ -930,12 +916,12 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://npm.genestack.com/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "glob-parent": {
       "version": "3.1.0",
-      "resolved": "https://npm.genestack.com/glob-parent/-/glob-parent-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
         "is-glob": "^3.1.0",
@@ -944,7 +930,7 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://npm.genestack.com/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
             "is-extglob": "^2.1.0"
@@ -953,13 +939,13 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://npm.genestack.com/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "has-ansi": {
       "version": "0.1.0",
-      "resolved": "https://npm.genestack.com/has-ansi/-/has-ansi-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
       "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
       "requires": {
         "ansi-regex": "^0.2.0"
@@ -967,7 +953,7 @@
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://npm.genestack.com/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
         "get-value": "^2.0.6",
@@ -977,7 +963,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://npm.genestack.com/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
         "is-number": "^3.0.0",
@@ -986,7 +972,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://npm.genestack.com/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -996,12 +982,12 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://npm.genestack.com/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://npm.genestack.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -1009,7 +995,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.genestack.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -1019,7 +1005,7 @@
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://npm.genestack.com/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
         "binary-extensions": "^1.0.0"
@@ -1027,12 +1013,12 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://npm.genestack.com/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://npm.genestack.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -1040,7 +1026,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.genestack.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -1050,7 +1036,7 @@
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://npm.genestack.com/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
@@ -1060,24 +1046,24 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "https://npm.genestack.com/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
         }
       }
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://npm.genestack.com/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://npm.genestack.com/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-glob": {
       "version": "4.0.0",
-      "resolved": "https://npm.genestack.com/is-glob/-/is-glob-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "requires": {
         "is-extglob": "^2.1.1"
@@ -1085,7 +1071,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "https://npm.genestack.com/is-number/-/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -1093,7 +1079,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.genestack.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -1103,7 +1089,7 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "https://npm.genestack.com/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
@@ -1111,47 +1097,47 @@
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "https://npm.genestack.com/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://npm.genestack.com/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://npm.genestack.com/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "https://npm.genestack.com/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "kind-of": {
       "version": "6.0.2",
-      "resolved": "https://npm.genestack.com/kind-of/-/kind-of-6.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://npm.genestack.com/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
-      "resolved": "https://npm.genestack.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://npm.genestack.com/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://npm.genestack.com/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
@@ -1159,7 +1145,7 @@
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "https://npm.genestack.com/micromatch/-/micromatch-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -1179,25 +1165,17 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://npm.genestack.com/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://npm.genestack.com/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://npm.genestack.com/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.1",
-      "resolved": "https://npm.genestack.com/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
         "for-in": "^1.0.2",
@@ -1206,7 +1184,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://npm.genestack.com/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -1216,7 +1194,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://npm.genestack.com/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -1224,25 +1202,25 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://npm.genestack.com/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://npm.genestack.com/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://npm.genestack.com/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "https://npm.genestack.com/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -1260,7 +1238,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://npm.genestack.com/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
         "remove-trailing-separator": "^1.0.1"
@@ -1268,7 +1246,7 @@
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://npm.genestack.com/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -1278,7 +1256,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.genestack.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -1286,7 +1264,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.genestack.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -1296,7 +1274,7 @@
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://npm.genestack.com/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
@@ -1304,39 +1282,39 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://npm.genestack.com/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
       }
     },
     "opn": {
-      "version": "5.3.0",
-      "resolved": "https://npm.genestack.com/opn/-/opn-5.3.0.tgz",
-      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+      "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
       "requires": {
         "is-wsl": "^1.1.0"
       }
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://npm.genestack.com/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://npm.genestack.com/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://npm.genestack.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "portfinder": {
-      "version": "1.0.13",
-      "resolved": "https://npm.genestack.com/portfinder/-/portfinder-1.0.13.tgz",
-      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
+      "integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
       "requires": {
         "async": "^1.5.2",
         "debug": "^2.2.0",
@@ -1345,17 +1323,17 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://npm.genestack.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://npm.genestack.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://npm.genestack.com/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -1365,29 +1343,21 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://npm.genestack.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://npm.genestack.com/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       }
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "https://npm.genestack.com/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -1396,50 +1366,45 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://npm.genestack.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://npm.genestack.com/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://npm.genestack.com/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://npm.genestack.com/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "https://npm.genestack.com/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://npm.genestack.com/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://npm.genestack.com/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
       }
     },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://npm.genestack.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-    },
     "set-value": {
       "version": "2.0.0",
-      "resolved": "https://npm.genestack.com/set-value/-/set-value-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -1450,7 +1415,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.genestack.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -1460,7 +1425,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "https://npm.genestack.com/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
         "base": "^0.11.1",
@@ -1475,7 +1440,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.genestack.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -1483,7 +1448,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.genestack.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -1493,7 +1458,7 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "https://npm.genestack.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
         "define-property": "^1.0.0",
@@ -1503,7 +1468,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -1511,7 +1476,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -1519,7 +1484,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "https://npm.genestack.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
@@ -1527,7 +1492,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "https://npm.genestack.com/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -1539,7 +1504,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "https://npm.genestack.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
         "kind-of": "^3.2.0"
@@ -1547,7 +1512,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.genestack.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -1557,12 +1522,12 @@
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://npm.genestack.com/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
-      "resolved": "https://npm.genestack.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
         "atob": "^2.1.1",
@@ -1574,12 +1539,12 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://npm.genestack.com/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "https://npm.genestack.com/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -1587,7 +1552,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://npm.genestack.com/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
         "define-property": "^0.2.5",
@@ -1596,7 +1561,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://npm.genestack.com/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -1606,7 +1571,7 @@
     },
     "static-server": {
       "version": "2.2.1",
-      "resolved": "https://npm.genestack.com/static-server/-/static-server-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/static-server/-/static-server-2.2.1.tgz",
       "integrity": "sha512-j5eeW6higxYNmXMIT8iHjsdiViTpQDthg7o+SHsRtqdbxscdHqBHXwrXjHC8hL3F0Tsu34ApUpDkwzMBPBsrLw==",
       "requires": {
         "chalk": "^0.5.1",
@@ -1618,22 +1583,15 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://npm.genestack.com/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://npm.genestack.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "strip-ansi": {
       "version": "0.3.0",
-      "resolved": "https://npm.genestack.com/strip-ansi/-/strip-ansi-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
       "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
       "requires": {
         "ansi-regex": "^0.2.1"
@@ -1641,12 +1599,12 @@
     },
     "supports-color": {
       "version": "0.2.0",
-      "resolved": "https://npm.genestack.com/supports-color/-/supports-color-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
       "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://npm.genestack.com/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -1654,7 +1612,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://npm.genestack.com/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -1664,7 +1622,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "https://npm.genestack.com/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
         "define-property": "^2.0.2",
@@ -1675,7 +1633,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://npm.genestack.com/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
         "is-number": "^3.0.0",
@@ -1684,12 +1642,12 @@
     },
     "ultron": {
       "version": "1.1.1",
-      "resolved": "https://npm.genestack.com/ultron/-/ultron-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "union-value": {
       "version": "1.0.0",
-      "resolved": "https://npm.genestack.com/union-value/-/union-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
         "arr-union": "^3.1.0",
@@ -1700,7 +1658,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://npm.genestack.com/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -1708,7 +1666,7 @@
         },
         "set-value": {
           "version": "0.4.3",
-          "resolved": "https://npm.genestack.com/set-value/-/set-value-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -1721,7 +1679,7 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://npm.genestack.com/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
         "has-value": "^0.3.1",
@@ -1730,7 +1688,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://npm.genestack.com/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
             "get-value": "^2.0.3",
@@ -1740,7 +1698,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://npm.genestack.com/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "requires": {
                 "isarray": "1.0.0"
@@ -1750,45 +1708,43 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://npm.genestack.com/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
       }
     },
     "unzip-response": {
       "version": "2.0.1",
-      "resolved": "https://npm.genestack.com/unzip-response/-/unzip-response-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
     },
     "upath": {
       "version": "1.1.0",
-      "resolved": "https://npm.genestack.com/upath/-/upath-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
       "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://npm.genestack.com/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "use": {
-      "version": "3.1.0",
-      "resolved": "https://npm.genestack.com/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://npm.genestack.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "ws": {
-      "version": "2.3.1",
-      "resolved": "https://npm.genestack.com/ws/-/ws-2.3.1.tgz",
-      "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
+      "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
       "requires": {
-        "safe-buffer": "~5.0.1",
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
       }
     }

--- a/packages/ui-proxy/package.json
+++ b/packages/ui-proxy/package.json
@@ -21,6 +21,6 @@
     "portfinder": "^1.0.13",
     "static-server": "^2.0.4",
     "unzip-response": "^2.0.1",
-    "ws": "^2.2.1"
+    "ws": "3.3.2"
   }
 }


### PR DESCRIPTION
* Changed repository in `package-lock.json` from `https://npm.genestack.com` to `https://registry.npmjs.org`
* Added link to main README
* fixed WS version due to [found vulnerability](https://www.npmjs.com/advisories/550)