### PR TITLE
UI Proxy: Fix URL replacer

### DIFF
--- a/packages/ui-proxy/package-lock.json
+++ b/packages/ui-proxy/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@genestack/ui-proxy",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ui-proxy/package.json
+++ b/packages/ui-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genestack/ui-proxy",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Proxy server for Genestack frontend development",
   "engines": {
     "node": ">=7.6.0"

--- a/packages/ui-proxy/src/create-proxy-server.js
+++ b/packages/ui-proxy/src/create-proxy-server.js
@@ -183,7 +183,7 @@ function preprocessResponse(...preprocessors) {
 }
 
 function replaceURLsInHTML(replacementHost, proxyAddress) {
-    const urlSearch = new RegExp(`['"]{1}((http(s?):\/\/.*${replacementHost}).+)['"]+`, 'gim');
+    const urlSearch = new RegExp(`['"]{1}((http(s?):\/\/.*${replacementHost}).+)['"]+`, 'gi');
     replacedUrls = {};
 
     return function(responseText) {

--- a/packages/ui-proxy/src/create-proxy-server.js
+++ b/packages/ui-proxy/src/create-proxy-server.js
@@ -63,7 +63,7 @@ function createProxyServer({
                     );
                     if (isHtml) {
                         preprocessResponse(
-                            replaceUrls(requestServerParams.host, getProxyAddress(proxyPort)),
+                            replaceURLsInHTML(requestServerParams.host, getProxyAddress(proxyPort)),
                             noReload ? _.identity : injectReloadScript(reloadScript)
                         )(
                             originalResponse,
@@ -182,9 +182,10 @@ function preprocessResponse(...preprocessors) {
     };
 }
 
-function replaceUrls(replacementHost, proxyAddress) {
-    const urlSearch = new RegExp(`((http.*${replacementHost}).+)['"]+`, 'g');
+function replaceURLsInHTML(replacementHost, proxyAddress) {
+    const urlSearch = new RegExp(`['"]{1}((http(s?):\/\/.*${replacementHost}).+)['"]+`, 'gim');
     replacedUrls = {};
+
     return function(responseText) {
         return responseText.replace(urlSearch, (match, oldUrl, replacement) => {
             replacedUrls[oldUrl.replace(replacement, proxyAddress)] = oldUrl;


### PR DESCRIPTION
Fixed: Bug when ui-proxy was replacing URLs incorrectly by corrupting HTML tag contents.