### PR TITLE
JBKB-1937: Remove content length from headers for html stream in UI-proxy

### DIFF
--- a/packages/ui-proxy/changelog.md
+++ b/packages/ui-proxy/changelog.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+## [1.0.4] - 2021-07-20
+
+### Fixed
+
+-   Remove content length from headers for html stream
+
 ## [1.0.3] - 2021-02-02
 
 ### Fixed

--- a/packages/ui-proxy/package-lock.json
+++ b/packages/ui-proxy/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@genestack/ui-proxy",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ui-proxy/package.json
+++ b/packages/ui-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genestack/ui-proxy",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Proxy server for Genestack frontend development",
   "engines": {
     "node": ">=7.6.0"

--- a/packages/ui-proxy/src/create-proxy-server.js
+++ b/packages/ui-proxy/src/create-proxy-server.js
@@ -148,7 +148,10 @@ function getStaticRedirectParameters(staticPort, requestedUrl) {
 
 function getResponseHeaders(originalHeaders, replaceHost, isUnzipped) {
     return _.reduce(originalHeaders, (newHeaders, value, headerName) => {
-        if (isUnzipped && headerName === 'content-encoding') {
+        // skip unzipped stream with special header name probably because
+        // content-encoding influences that the browser to decode data incorrectly (net::ERR_CONTENT_DECODING_FAILED)
+        // content-length influences that HTML will be partial loaded
+        if (isUnzipped && ['content-encoding', 'content-length'].includes(headerName)) {
             return newHeaders;
         }
         if (Array.isArray(value)) {


### PR DESCRIPTION
If we send the length of the content in the headers for the html stream, we can see the partially loaded html.
This PR will fix this issue